### PR TITLE
When used as a library, return a Promise

### DIFF
--- a/bin/obj23dtiles.js
+++ b/bin/obj23dtiles.js
@@ -257,4 +257,8 @@ var options = {
     outputDirectory : outputDirectory
 };
 
-obj23dtiles(objPath, outputPath, options);
+console.time('Total');
+obj23dtiles(objPath, outputPath, options)
+    .then(() => {
+        console.timeEnd('Total');
+    });

--- a/lib/obj23dtiles.js
+++ b/lib/obj23dtiles.js
@@ -11,7 +11,6 @@ module.exports = obj23dtiles;
 obj23dtiles.combine = combine;
 
 function obj23dtiles(objPath, outputPath, options) {
-    console.time('Total');
 
     if(typeof options.tilesetOptions === 'string') {
         options.tilesetOptions = fsExtra.readJsonSync(options.tilesetOptions);
@@ -29,7 +28,7 @@ function obj23dtiles(objPath, outputPath, options) {
             options.batchId = true;
             options.b3dm = true;
 
-            obj2Tileset(objPath, outputPath, options)
+            return obj2Tileset(objPath, outputPath, options)
                 .then(function(result) {
                     var b3dm = result.b3dm;
                     var batchTableJson = result.batchTableJson;
@@ -49,9 +48,6 @@ function obj23dtiles(objPath, outputPath, options) {
                     tasks.push(fsExtra.writeJson(tilesetPath, tileset, {spaces: 2}));
                     return Promise.all(tasks);
                 })
-                .then(function() {
-                    console.timeEnd('Total');
-                })
                 .catch(function(error) {
                     console.log(error.message || error);
                     process.exit(1);
@@ -64,7 +60,7 @@ function obj23dtiles(objPath, outputPath, options) {
                 process.exit(1);
             }
 
-            obj2Tileset(objPath, outputPath, options)
+            return obj2Tileset(objPath, outputPath, options)
                 .then(function(result) {
                     var i3dm = result.i3dm;
                     var batchTableJson = result.batchTableJson;
@@ -84,9 +80,6 @@ function obj23dtiles(objPath, outputPath, options) {
                     tasks.push(fsExtra.writeJson(tilesetPath, tileset, {spaces: 2}));
                     return Promise.all(tasks);
                 })
-                .then(function() {
-                    console.timeEnd('Total');
-                })
                 .catch(function(error) {
                     console.log(error.message || error);
                     process.exit(1);
@@ -96,7 +89,7 @@ function obj23dtiles(objPath, outputPath, options) {
     else if (options && options.b3dm) {
         options.binary = true;
         options.batchId = true;
-        obj2B3dm(objPath, options)
+        return obj2B3dm(objPath, options)
             .then(function(result){
                 var b3dm = result.b3dm;
                 var batchTableJson = result.batchTableJson;
@@ -108,9 +101,6 @@ function obj23dtiles(objPath, outputPath, options) {
                 }
                 fsExtra.ensureDirSync(path.dirname(outputPath));
                 return fsExtra.outputFile(outputPath, b3dm);
-            })
-            .then(function() {
-                console.timeEnd('Total');
             })
             .catch(function(error) {
                 console.log(error.message || error);
@@ -124,7 +114,7 @@ function obj23dtiles(objPath, outputPath, options) {
             console.log('Convert to i3dm need a custom FeatureTable.');
             process.exit(1);
         }
-        obj2I3dm(objPath, options)
+        return obj2I3dm(objPath, options)
             .then(function(result){
                 var i3dm = result.i3dm;
                 var batchTableJson = result.batchTableJson;
@@ -137,16 +127,13 @@ function obj23dtiles(objPath, outputPath, options) {
                 fsExtra.ensureDirSync(path.dirname(outputPath));
                 return fsExtra.outputFile(outputPath, i3dm);
             })
-            .then(function() {
-                console.timeEnd('Total');
-            })
             .catch(function(error) {
                 console.log(error.message || error);
                 process.exit(1);
             });
     }
     else {
-        obj2gltf(objPath, options)
+        return obj2gltf(objPath, options)
             .then(function(result){
                 var gltf = result.gltf;
                 if (options && options.binary) {
@@ -157,9 +144,6 @@ function obj23dtiles(objPath, outputPath, options) {
                     spaces : 2
                 };
                 return fsExtra.outputJson(outputPath, gltf, jsonOptions);
-            })
-            .then(function() {
-                console.timeEnd('Total');
             })
             .catch(function(error) {
                 console.log(error.message || error);


### PR DESCRIPTION
The main function `obj23dtiles(objPath, outputPath, options)` used to return `undefined`, although there is much asynchronicity properly used inside of it. Because of this, it was not possible to properly wait on completion -- the only option would be to spawn `node` in a child process and wait for it to exit.

This pull request makes the relevant Promise to be returned outside, so that it is possible to just `await obj23dtiles(...)`.

Note, other issues may arise from `process.exit` being used in the library code. Such calls should be moved to `bin/obj23dtiles.js` solely but I tried to keep this pull request as humble as possible.