### PR TITLE
fix url bug

### DIFF
--- a/lib/combineTileset.js
+++ b/lib/combineTileset.js
@@ -45,7 +45,7 @@ function combineTileset(options) {
                 if (defined(boundingVolume) && defined(geometricError)) {
                     // Use external tileset instand of b3dm.
                     var url = path.relative(outputDir, jsonFile);
-                    url = url.replace(/\\/g, '/');
+                    url = url.replace(/\\/g, '/').replace(/#/gi, '%23').replace(/ /gi, '%20');
 
                     // Only support region for now.
                     if(boundingVolume.region) {


### PR DESCRIPTION
解决文件路径中有 # 或空格时，被浏览器截断的问题